### PR TITLE
Small fix luno parseOrder

### DIFF
--- a/js/luno.js
+++ b/js/luno.js
@@ -143,7 +143,7 @@ module.exports = class luno extends Exchange {
         let amount = this.safeFloat (order, 'limit_volume');
         let quoteFee = this.safeFloat (order, 'fee_counter');
         let baseFee = this.safeFloat (order, 'fee_base');
-        let filled = this.safeFloat (order, 'filled');
+        let filled = this.safeFloat (order, 'base');
         let remaining = undefined;
         if (typeof amount !== 'undefined') {
             if (typeof filled !== 'undefined') {


### PR DESCRIPTION
Correctly matching filled value to API response "base"